### PR TITLE
Docker multi-staging 기술을 이용한 CI/CD 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM gradle:jdk17-alpine as build
 WORKDIR /app
 COPY . .
+RUN chmod +x gradlew
 RUN ./gradlew clean build
 
 # deploy stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+# build stage
+FROM gradle:jdk17-alpine as build
+WORKDIR /app
+COPY . .
+RUN ./gradlew clean build
+
+# deploy stage
 FROM openjdk:17
-COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+WORKDIR /app
+COPY --from=build /app/build/libs/** /app/app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
기존에 CICD를 구현하기 위해서는 빌드 전용 서버를 별도로 사용하거나 젠킨스, Github Action과 같은 서비스를 이용해야 했습니다.
하지만 이러한 과정은 중간에 설정 및 관리해주어야하는 포인트가 늘어난다는 단점을 가지고 있었고 구현 난이도 또한 높습니다.
하지만 도커에서 지원하는 multi-staging 기법을 이용해서 빌드와 이미지 생성이 별도로 동작하도록 구현했고 불필요한 파일과 데이터는 이미지에 추가하지 않음으로써 이미지 경량화와 성능 향상을 이끌어냈고 빌드 과정의 구현 난이도를 기존의 방식보다 상대적으로 낮출 수 있었습니다.