### PR TITLE
강의실, 기자재 도메인 로직 작성

### DIFF
--- a/src/main/kotlin/com/teamteam/backend/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/teamteam/backend/config/SecurityConfig.kt
@@ -45,10 +45,17 @@ class SecurityConfig(
             .formLogin().disable()
             .authorizeHttpRequests()
             .requestMatchers("/ping").permitAll()
+
             .requestMatchers(HttpMethod.GET, "/api/building/**").hasAnyRole("ADMIN", "STUDENT")
             .requestMatchers(HttpMethod.POST, "/api/building/**").hasRole("ADMIN")
             .requestMatchers(HttpMethod.PUT, "/api/building/**").hasRole("ADMIN")
             .requestMatchers(HttpMethod.DELETE, "/api/building/**").hasRole("ADMIN")
+
+            .requestMatchers(HttpMethod.GET, "/api/room/**").hasAnyRole("ADMIN", "STUDENT")
+            .requestMatchers(HttpMethod.POST, "/api/room/**").hasRole("ADMIN")
+            .requestMatchers(HttpMethod.PUT, "/api/room/**").hasRole("ADMIN")
+            .requestMatchers(HttpMethod.DELETE, "/api/room/**").hasRole("ADMIN")
+
             .requestMatchers("/v3/api-docs/**", "/swagger/**", "/swagger-ui.html" , "/swagger-ui/**").permitAll()
             .anyRequest().denyAll() // deny all request that we are not using
             .and()

--- a/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingReadSimpleDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingReadSimpleDTO.kt
@@ -1,0 +1,18 @@
+package com.teamteam.backend.domain.building.dto
+
+import com.teamteam.backend.domain.building.entity.Building
+import com.teamteam.backend.domain.building.error.BuildingNotFoundException
+
+class BuildingReadSimpleDTO(
+    val id: String,
+    val name: String,
+    val description: String
+) {
+    companion object {
+        fun from(building: Building) = BuildingReadSimpleDTO(
+            id = building.id ?: throw BuildingNotFoundException(),
+            name = building.name,
+            description = building.description
+        )
+    }
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/building/error/BuildingNoPermissionException.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/building/error/BuildingNoPermissionException.kt
@@ -1,0 +1,13 @@
+package com.teamteam.backend.domain.building.error
+
+import com.teamteam.backend.shared.dto.ErrorResponse
+import com.teamteam.backend.shared.error.TeamTeamRuntimeException
+
+
+class BuildingNoPermissionException : TeamTeamRuntimeException(
+    ErrorResponse(
+        message = "building no permission error",
+        code = "BUILDING_NO_PERMISSION_ERROR",
+        status = 500
+    )
+)

--- a/src/main/kotlin/com/teamteam/backend/domain/equipment/entity/Equipment.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/equipment/entity/Equipment.kt
@@ -1,0 +1,14 @@
+package com.teamteam.backend.domain.equipment.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "equipment")
+class Equipment(
+    @Id
+    var id : String? = null,
+    @Enumerated(EnumType.STRING)
+    var type : EquipmentType,
+    @Column(name = "room_id")
+    var roomId : String
+)

--- a/src/main/kotlin/com/teamteam/backend/domain/equipment/entity/EquipmentType.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/equipment/entity/EquipmentType.kt
@@ -1,0 +1,5 @@
+package com.teamteam.backend.domain.equipment.entity
+
+enum class EquipmentType {
+    BOARD_MARKER, PROJECTOR, WHITEBOARD, CHALKBOARD, CHALK, PAPER, PENCIL, ERASER, PEN, SCISSORS, TAPE, GLUE, STAPLER, STAPLES, RULER, PAPERCLIP
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/equipment/error/EquipmentNotFoundException.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/equipment/error/EquipmentNotFoundException.kt
@@ -1,0 +1,12 @@
+package com.teamteam.backend.domain.equipment.error
+
+import com.teamteam.backend.shared.dto.ErrorResponse
+import com.teamteam.backend.shared.error.TeamTeamRuntimeException
+
+class EquipmentNotFoundException : TeamTeamRuntimeException(
+    ErrorResponse(
+        code = "EQUIPMENT_NOT_FOUND",
+        message = "해당하는 장비를 찾을 수 없습니다.",
+        status = 404
+    )
+)

--- a/src/main/kotlin/com/teamteam/backend/domain/equipment/repository/EquipmentRepository.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/equipment/repository/EquipmentRepository.kt
@@ -1,0 +1,9 @@
+package com.teamteam.backend.domain.equipment.repository
+
+import com.teamteam.backend.domain.equipment.entity.Equipment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface EquipmentRepository : JpaRepository<Equipment, String> {
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/equipment/repository/EquipmentRepository.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/equipment/repository/EquipmentRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface EquipmentRepository : JpaRepository<Equipment, String> {
+    fun findAllByRoomId(roomId: String): List<Equipment>
+    fun deleteAllByRoomId(roomId: String)
 }

--- a/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomCreateDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomCreateDTO.kt
@@ -1,0 +1,18 @@
+package com.teamteam.backend.domain.room.dto
+
+import com.teamteam.backend.domain.equipment.entity.EquipmentType
+import com.teamteam.backend.domain.room.entity.Room
+
+class RoomCreateDTO(
+    val name: String,
+    val capacity: Long,
+    val description: String,
+    val equipments: Set<EquipmentType>
+) {
+    fun toEntity(buildingId: String): Room = Room(
+        buildingId = buildingId,
+        name = name,
+        capacity = capacity,
+        description = description
+    )
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomReadDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomReadDTO.kt
@@ -1,0 +1,30 @@
+package com.teamteam.backend.domain.room.dto
+
+import com.teamteam.backend.domain.building.dto.BuildingReadSimpleDTO
+import com.teamteam.backend.domain.building.entity.Building
+import com.teamteam.backend.domain.equipment.entity.Equipment
+import com.teamteam.backend.domain.equipment.entity.EquipmentType
+import com.teamteam.backend.domain.room.entity.Room
+import com.teamteam.backend.domain.room.error.RoomNotFoundException
+
+class RoomReadDTO(
+    val id: String,
+    val building: BuildingReadSimpleDTO,
+    val name: String,
+    val capacity: Long,
+    val description: String,
+    val equipments: Set<EquipmentType>
+) {
+    companion object {
+        fun from(building: Building, room: Room, equipments: List<Equipment>): RoomReadDTO {
+            return RoomReadDTO(
+                id = room.id ?: throw RoomNotFoundException(),
+                building = BuildingReadSimpleDTO.from(building),
+                name = room.name,
+                capacity = room.capacity,
+                description = room.description,
+                equipments = equipments.map { it.type }.toSet()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomUpdateDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomUpdateDTO.kt
@@ -1,0 +1,10 @@
+package com.teamteam.backend.domain.room.dto
+
+import com.teamteam.backend.domain.equipment.entity.EquipmentType
+
+class RoomUpdateDTO(
+    val name : String,
+    val capacity : Long,
+    val description : String,
+    val equipments : Set<EquipmentType>
+)

--- a/src/main/kotlin/com/teamteam/backend/domain/room/entity/Room.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/entity/Room.kt
@@ -1,0 +1,18 @@
+package com.teamteam.backend.domain.room.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "room")
+class Room(
+    @Id
+    var id: String? = null,
+    @Column(name = "building_id")
+    var buildingId: String,
+    var name: String,
+    var description: String,
+    var capacity: Long,
+)

--- a/src/main/kotlin/com/teamteam/backend/domain/room/entity/Room.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/entity/Room.kt
@@ -15,4 +15,10 @@ class Room(
     var name: String,
     var description: String,
     var capacity: Long,
-)
+) {
+    fun update(name: String = this.name, description: String = this.description, capacity: Long = this.capacity) {
+        this.name = name
+        this.description = description
+        this.capacity = capacity
+    }
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/room/error/RoomCreateException.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/error/RoomCreateException.kt
@@ -1,0 +1,13 @@
+package com.teamteam.backend.domain.room.error
+
+import com.teamteam.backend.shared.dto.ErrorResponse
+import com.teamteam.backend.shared.error.TeamTeamRuntimeException
+
+class RoomCreateException : TeamTeamRuntimeException(
+    ErrorResponse(
+        message = "id not found error",
+        code = "ROOM_CREATE_ERROR",
+        status = 500
+    )
+) {
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/room/error/RoomNotFoundException.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/error/RoomNotFoundException.kt
@@ -1,0 +1,13 @@
+package com.teamteam.backend.domain.room.error
+
+import com.teamteam.backend.shared.dto.ErrorResponse
+import com.teamteam.backend.shared.error.TeamTeamRuntimeException
+
+class RoomNotFoundException : TeamTeamRuntimeException(
+    ErrorResponse(
+        message = "room not found error",
+        code = "ROOM_NOT_FOUND_ERROR",
+        status = 500
+    )
+) {
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/room/repository/RoomRepository.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/repository/RoomRepository.kt
@@ -1,0 +1,9 @@
+package com.teamteam.backend.domain.room.repository
+
+import com.teamteam.backend.domain.room.entity.Room
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RoomRepository : JpaRepository<Room, String> {
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/room/service/RoomService.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/service/RoomService.kt
@@ -1,0 +1,47 @@
+package com.teamteam.backend.domain.room.service
+
+import com.teamteam.backend.domain.building.error.BuildingNoPermissionException
+import com.teamteam.backend.domain.building.error.BuildingNotFoundException
+import com.teamteam.backend.domain.building.repository.BuildingRepository
+import com.teamteam.backend.domain.equipment.entity.Equipment
+import com.teamteam.backend.domain.equipment.repository.EquipmentRepository
+import com.teamteam.backend.domain.generator.IdentifierProvider
+import com.teamteam.backend.domain.room.dto.RoomCreateDTO
+import com.teamteam.backend.domain.room.dto.RoomReadDTO
+import com.teamteam.backend.domain.room.error.RoomCreateException
+import com.teamteam.backend.domain.room.repository.RoomRepository
+import com.teamteam.backend.shared.security.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class RoomService(
+    private val roomRepository: RoomRepository,
+    private val buildingRepository: BuildingRepository,
+    private val equipmentRepository: EquipmentRepository,
+    private val provider: IdentifierProvider
+) {
+    // create
+    @Transactional
+    fun create(user: User, buildingId: String, dto: RoomCreateDTO): RoomReadDTO {
+        val building = buildingRepository.findById(buildingId).orElseThrow { throw BuildingNotFoundException() }
+        // 권한 체크
+        if (building.adminId != user.id) throw BuildingNoPermissionException()
+
+        val room = dto.toEntity(buildingId)
+        // 방 저장
+        room.id = provider.generate()
+        roomRepository.save(room)
+
+        // 기자재 저장
+        val equipments = dto.equipments.map { type ->
+            Equipment(
+                id = provider.generate(),
+                type = type,
+                roomId = room.id ?: throw RoomCreateException()
+            )
+        }.let { equipmentRepository.saveAll(it) }
+
+        return RoomReadDTO.from(building, room, equipments)
+    }
+}

--- a/src/main/kotlin/com/teamteam/backend/domain/room/service/RoomService.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/service/RoomService.kt
@@ -4,11 +4,15 @@ import com.teamteam.backend.domain.building.error.BuildingNoPermissionException
 import com.teamteam.backend.domain.building.error.BuildingNotFoundException
 import com.teamteam.backend.domain.building.repository.BuildingRepository
 import com.teamteam.backend.domain.equipment.entity.Equipment
+import com.teamteam.backend.domain.equipment.error.EquipmentNotFoundException
 import com.teamteam.backend.domain.equipment.repository.EquipmentRepository
 import com.teamteam.backend.domain.generator.IdentifierProvider
 import com.teamteam.backend.domain.room.dto.RoomCreateDTO
 import com.teamteam.backend.domain.room.dto.RoomReadDTO
+import com.teamteam.backend.domain.room.dto.RoomUpdateDTO
+import com.teamteam.backend.domain.room.entity.Room
 import com.teamteam.backend.domain.room.error.RoomCreateException
+import com.teamteam.backend.domain.room.error.RoomNotFoundException
 import com.teamteam.backend.domain.room.repository.RoomRepository
 import com.teamteam.backend.shared.security.User
 import org.springframework.stereotype.Service
@@ -21,19 +25,32 @@ class RoomService(
     private val equipmentRepository: EquipmentRepository,
     private val provider: IdentifierProvider
 ) {
-    // create
+    //*** read only domain logic ***//
+    @Transactional(readOnly = true)
+    fun findAll(): List<RoomReadDTO> = roomRepository.findAll().map { room ->
+        val building = buildingRepository.findById(room.buildingId).orElseThrow { throw BuildingNotFoundException() }
+        val equipments = equipmentRepository.findAllByRoomId(room.id ?: throw EquipmentNotFoundException())
+        RoomReadDTO.from(building, room, equipments)
+    }
+
+    @Transactional(readOnly = true)
+    fun findById(roomId: String): RoomReadDTO = roomRepository.findById(roomId)
+        .orElseThrow { throw RoomNotFoundException() }
+        .let { room ->
+            val building =
+                buildingRepository.findById(room.buildingId).orElseThrow { throw BuildingNotFoundException() }
+            val equipments = equipmentRepository.findAllByRoomId(room.id ?: throw EquipmentNotFoundException())
+            RoomReadDTO.from(building, room, equipments)
+        }
+
+    //*** command domain logic ***//
     @Transactional
     fun create(user: User, buildingId: String, dto: RoomCreateDTO): RoomReadDTO {
         val building = buildingRepository.findById(buildingId).orElseThrow { throw BuildingNotFoundException() }
-        // 권한 체크
         if (building.adminId != user.id) throw BuildingNoPermissionException()
-
         val room = dto.toEntity(buildingId)
-        // 방 저장
         room.id = provider.generate()
         roomRepository.save(room)
-
-        // 기자재 저장
         val equipments = dto.equipments.map { type ->
             Equipment(
                 id = provider.generate(),
@@ -41,7 +58,37 @@ class RoomService(
                 roomId = room.id ?: throw RoomCreateException()
             )
         }.let { equipmentRepository.saveAll(it) }
-
         return RoomReadDTO.from(building, room, equipments)
+    }
+
+    @Transactional
+    fun update(user: User, roomId: String, dto: RoomUpdateDTO): RoomReadDTO {
+        // 권한 확인
+        val room: Room = roomRepository.findById(roomId).orElseThrow { throw RoomNotFoundException() }
+        val building = buildingRepository.findById(room.buildingId).orElseThrow { throw BuildingNotFoundException() }
+        if (building.adminId != user.id) throw BuildingNoPermissionException()
+
+        //기존의 기자재 정보를 삭제
+        equipmentRepository.deleteAllByRoomId(roomId)
+
+        // 새롭게 정보 업데이트 및 새롭게 기자재 추가
+        room.update(name = dto.name, capacity = dto.capacity, description = dto.description)
+        val equipments = dto.equipments.map { type ->
+            Equipment(
+                id = provider.generate(),
+                type = type,
+                roomId = room.id ?: throw RoomCreateException()
+            )
+        }.let { equipmentRepository.saveAll(it) }
+        return RoomReadDTO.from(building, room, equipments)
+    }
+
+    @Transactional
+    fun delete(user: User, roomId: String) {
+        val room = roomRepository.findById(roomId).orElseThrow { throw RoomNotFoundException() }
+        val building = buildingRepository.findById(room.buildingId).orElseThrow { throw BuildingNotFoundException() }
+        if (building.adminId != user.id) throw BuildingNoPermissionException()
+        roomRepository.deleteById(roomId)
+        equipmentRepository.deleteAllByRoomId(roomId)
     }
 }

--- a/src/main/kotlin/com/teamteam/backend/shared/security/JwtFilter.kt
+++ b/src/main/kotlin/com/teamteam/backend/shared/security/JwtFilter.kt
@@ -1,11 +1,35 @@
 package com.teamteam.backend.shared.security
 
 import jakarta.servlet.FilterChain
+import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
+
+//@Component
+//class JwtFilter(
+//    private val jwtService: JwtService
+//) : OncePerRequestFilter() {
+//    override fun doFilterInternal(
+//        request: HttpServletRequest,
+//        response: HttpServletResponse,
+//        filterChain: FilterChain
+//    ) {
+//        val bearer:String? = request.getHeader("Authorization")
+//        if(bearer == null){
+//            logger.info("bearer is null")
+//            filterChain.doFilter(request, response)
+//            return
+//        }
+//        val jwt:String = bearer.substring("Bearer ".length)
+//        val authentication = jwtService.createAuthenticationToken(jwt)
+//        SecurityContextHolder.getContext().authentication = authentication
+//        filterChain.doFilter(request, response)
+//    }
+//}
+
 
 @Component
 class JwtFilter(
@@ -16,13 +40,13 @@ class JwtFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        val bearer:String? = request.getHeader("Authorization")
-        if(bearer == null){
-            logger.info("bearer is null")
+        val cookie : Cookie? = request.cookies?.find { it.name == "cat" }
+        if(cookie == null){
+            logger.info("cat cookie is null")
             filterChain.doFilter(request, response)
             return
         }
-        val jwt:String = bearer.substring("Bearer ".length)
+        val jwt = cookie.value
         val authentication = jwtService.createAuthenticationToken(jwt)
         SecurityContextHolder.getContext().authentication = authentication
         filterChain.doFilter(request, response)

--- a/src/main/kotlin/com/teamteam/backend/web/room/RoomController.kt
+++ b/src/main/kotlin/com/teamteam/backend/web/room/RoomController.kt
@@ -2,22 +2,30 @@ package com.teamteam.backend.web.room
 
 import com.teamteam.backend.domain.room.dto.RoomCreateDTO
 import com.teamteam.backend.domain.room.dto.RoomReadDTO
+import com.teamteam.backend.domain.room.dto.RoomUpdateDTO
 import com.teamteam.backend.domain.room.service.RoomService
+import com.teamteam.backend.shared.dto.CommonResponse
 import com.teamteam.backend.shared.security.User
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/room")
 class RoomController(
     private val roomService: RoomService
 ) {
+    //*** read only endpoint ***//
+    @GetMapping("")
+    fun findAll(): ResponseEntity<List<RoomReadDTO>> = ResponseEntity.ok(roomService.findAll())
+
+
+    @GetMapping("/{roomId}")
+    fun findById(@PathVariable roomId: String): ResponseEntity<RoomReadDTO> =
+        ResponseEntity.ok(roomService.findById(roomId))
+
+    //*** command endpoint ***//
     @PostMapping("/{buildingId}")
     fun create(
         authentication: Authentication,
@@ -26,5 +34,31 @@ class RoomController(
     ): ResponseEntity<RoomReadDTO> {
         val user = authentication.principal as User
         return ResponseEntity.status(HttpStatus.CREATED).body(roomService.create(user, buildingId, dto))
+    }
+
+    @PutMapping("/{roomId}")
+    fun update(
+        authentication: Authentication,
+        @PathVariable roomId: String,
+        @RequestBody dto: RoomUpdateDTO
+    ): ResponseEntity<RoomReadDTO> {
+        val user = authentication.principal as User
+        return ResponseEntity.ok(roomService.update(user, roomId, dto))
+    }
+
+    @DeleteMapping("/{roomId}")
+    fun delete(
+        authentication: Authentication,
+        @PathVariable roomId: String
+    ): ResponseEntity<CommonResponse> {
+        val user = authentication.principal as User
+        roomService.delete(user, roomId)
+        return ResponseEntity.ok(
+            CommonResponse(
+                message = "Room deleted successfully",
+                code = "room_delete_success",
+                status = 200
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/teamteam/backend/web/room/RoomController.kt
+++ b/src/main/kotlin/com/teamteam/backend/web/room/RoomController.kt
@@ -1,0 +1,30 @@
+package com.teamteam.backend.web.room
+
+import com.teamteam.backend.domain.room.dto.RoomCreateDTO
+import com.teamteam.backend.domain.room.dto.RoomReadDTO
+import com.teamteam.backend.domain.room.service.RoomService
+import com.teamteam.backend.shared.security.User
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/room")
+class RoomController(
+    private val roomService: RoomService
+) {
+    @PostMapping("/{buildingId}")
+    fun create(
+        authentication: Authentication,
+        @PathVariable buildingId: String,
+        @RequestBody dto: RoomCreateDTO
+    ): ResponseEntity<RoomReadDTO> {
+        val user = authentication.principal as User
+        return ResponseEntity.status(HttpStatus.CREATED).body(roomService.create(user, buildingId, dto))
+    }
+}


### PR DESCRIPTION
강의실 조회, 생성, 수정, 삭제 로직을 구현했습니다.
강의실 조회는 모든 사용자가 가능하고,
강의실 생성, 수정, 삭제는 '해당 건물의 관리자'만 가능하도록 구현했습니다.
기자재 도메인의 경우 일반적으로 강의실이 조회되고 생성될때 같이 사용되기 때문에 별도의 API를 만들지 않는 것이 맞다고 판단했습니다.