### PR TITLE
entity id가 불필요하게 nullable한 부분 수정

### DIFF
--- a/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingCreateDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingCreateDTO.kt
@@ -9,8 +9,9 @@ class BuildingCreateDTO (
     val description: String,
     val imageUrl: String
 ){
-    fun toEntity(user:User): Building {
+    fun toEntity(buildingId : String, user:User): Building {
         return Building(
+            id = buildingId,
             name = this.name,
             adminId = user.id,
             location = this.location,

--- a/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingReadDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingReadDTO.kt
@@ -14,7 +14,7 @@ class BuildingReadDTO(
 
     companion object {
         fun from(building: Building, user: User) = BuildingReadDTO(
-            id = building.id!!,
+            id = building.id,
             manager = ManagerReadDTO(id = user.id, username = user.username),
             name = building.name,
             location = building.location,

--- a/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingReadSimpleDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/building/dto/BuildingReadSimpleDTO.kt
@@ -1,7 +1,6 @@
 package com.teamteam.backend.domain.building.dto
 
 import com.teamteam.backend.domain.building.entity.Building
-import com.teamteam.backend.domain.building.error.BuildingNotFoundException
 
 class BuildingReadSimpleDTO(
     val id: String,
@@ -10,7 +9,7 @@ class BuildingReadSimpleDTO(
 ) {
     companion object {
         fun from(building: Building) = BuildingReadSimpleDTO(
-            id = building.id ?: throw BuildingNotFoundException(),
+            id = building.id,
             name = building.name,
             description = building.description
         )

--- a/src/main/kotlin/com/teamteam/backend/domain/building/entity/Building.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/building/entity/Building.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.Id
 @Entity(name = "building")
 class Building(
     @Id
-    var id: String? = null,
+    var id: String,
     @Column(name = "admin_id")
     var adminId : String,
     var name: String,

--- a/src/main/kotlin/com/teamteam/backend/domain/building/service/BuildingService.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/building/service/BuildingService.kt
@@ -46,8 +46,7 @@ class BuildingService(
         // name is unique check
         if (buildingRepository.existsByName(dto.name))
             throw BuildingNameConflictException()
-        val building = dto.toEntity(user)
-        building.id = provider.generate() // id generate
+        val building = dto.toEntity(provider.generate(), user)
         return BuildingReadDTO.from(buildingRepository.save(building), user)
     }
 

--- a/src/main/kotlin/com/teamteam/backend/domain/equipment/entity/Equipment.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/equipment/entity/Equipment.kt
@@ -6,7 +6,7 @@ import jakarta.persistence.*
 @Table(name = "equipment")
 class Equipment(
     @Id
-    var id : String? = null,
+    var id : String,
     @Enumerated(EnumType.STRING)
     var type : EquipmentType,
     @Column(name = "room_id")

--- a/src/main/kotlin/com/teamteam/backend/domain/reservation/dto/ReservationSummaryReadDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/reservation/dto/ReservationSummaryReadDTO.kt
@@ -5,7 +5,6 @@ import com.teamteam.backend.domain.member.dto.MemberReadDTO
 import com.teamteam.backend.domain.reservation.entity.ReservationStatus
 import com.teamteam.backend.domain.reservation.entity.ReservationSummary
 import com.teamteam.backend.domain.reservation.entity.ReservationTime
-import com.teamteam.backend.domain.reservation.error.ReservationNotFoundException
 import com.teamteam.backend.domain.room.dto.RoomReadDTO
 import java.time.DayOfWeek
 import java.time.LocalDate

--- a/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomCreateDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomCreateDTO.kt
@@ -9,7 +9,8 @@ class RoomCreateDTO(
     val description: String,
     val equipments: Set<EquipmentType>
 ) {
-    fun toEntity(buildingId: String): Room = Room(
+    fun toEntity(roomId:String, buildingId: String): Room = Room(
+        id = roomId,
         buildingId = buildingId,
         name = name,
         capacity = capacity,

--- a/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomReadDTO.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/dto/RoomReadDTO.kt
@@ -5,7 +5,6 @@ import com.teamteam.backend.domain.building.entity.Building
 import com.teamteam.backend.domain.equipment.entity.Equipment
 import com.teamteam.backend.domain.equipment.entity.EquipmentType
 import com.teamteam.backend.domain.room.entity.Room
-import com.teamteam.backend.domain.room.error.RoomNotFoundException
 
 class RoomReadDTO(
     val id: String,
@@ -18,7 +17,7 @@ class RoomReadDTO(
     companion object {
         fun from(building: Building, room: Room, equipments: List<Equipment>): RoomReadDTO {
             return RoomReadDTO(
-                id = room.id ?: throw RoomNotFoundException(),
+                id = room.id,
                 building = BuildingReadSimpleDTO.from(building),
                 name = room.name,
                 capacity = room.capacity,

--- a/src/main/kotlin/com/teamteam/backend/domain/room/entity/Room.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/entity/Room.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.Table
 @Table(name = "room")
 class Room(
     @Id
-    var id: String? = null,
+    var id: String,
     @Column(name = "building_id")
     var buildingId: String,
     var name: String,

--- a/src/main/kotlin/com/teamteam/backend/domain/room/service/RoomService.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/room/service/RoomService.kt
@@ -4,18 +4,15 @@ import com.teamteam.backend.domain.building.error.BuildingNoPermissionException
 import com.teamteam.backend.domain.building.error.BuildingNotFoundException
 import com.teamteam.backend.domain.building.repository.BuildingRepository
 import com.teamteam.backend.domain.equipment.entity.Equipment
-import com.teamteam.backend.domain.equipment.error.EquipmentNotFoundException
 import com.teamteam.backend.domain.equipment.repository.EquipmentRepository
 import com.teamteam.backend.domain.generator.IdentifierProvider
 import com.teamteam.backend.domain.room.dto.RoomCreateDTO
 import com.teamteam.backend.domain.room.dto.RoomReadDTO
 import com.teamteam.backend.domain.room.dto.RoomUpdateDTO
 import com.teamteam.backend.domain.room.entity.Room
-import com.teamteam.backend.domain.room.error.RoomCreateException
 import com.teamteam.backend.domain.room.error.RoomNotFoundException
 import com.teamteam.backend.domain.room.repository.RoomRepository
 import com.teamteam.backend.shared.security.User
-import jakarta.validation.constraints.AssertFalse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -30,7 +27,7 @@ class RoomService(
     @Transactional(readOnly = true)
     fun findAll(): List<RoomReadDTO> = roomRepository.findAll().map { room ->
         val building = buildingRepository.findById(room.buildingId).orElseThrow { throw BuildingNotFoundException() }
-        val equipments = equipmentRepository.findAllByRoomId(room.id ?: throw EquipmentNotFoundException())
+        val equipments = equipmentRepository.findAllByRoomId(room.id)
         RoomReadDTO.from(building, room, equipments)
     }
 
@@ -40,7 +37,7 @@ class RoomService(
         .let { room ->
             val building =
                 buildingRepository.findById(room.buildingId).orElseThrow { throw BuildingNotFoundException() }
-            val equipments = equipmentRepository.findAllByRoomId(room.id ?: throw EquipmentNotFoundException())
+            val equipments = equipmentRepository.findAllByRoomId(room.id)
             RoomReadDTO.from(building, room, equipments)
         }
 
@@ -49,14 +46,13 @@ class RoomService(
     fun create(user: User, buildingId: String, dto: RoomCreateDTO): RoomReadDTO {
         val building = buildingRepository.findById(buildingId).orElseThrow { throw BuildingNotFoundException() }
         if (building.adminId != user.id) throw BuildingNoPermissionException()
-        val room = dto.toEntity(buildingId)
-        room.id = provider.generate()
+        val room = dto.toEntity(provider.generate(), buildingId)
         roomRepository.save(room)
         val equipments = dto.equipments.map { type ->
             Equipment(
                 id = provider.generate(),
                 type = type,
-                roomId = room.id ?: throw RoomCreateException()
+                roomId = room.id
             )
         }.let { equipmentRepository.saveAll(it) }
         return RoomReadDTO.from(building, room, equipments)
@@ -78,7 +74,7 @@ class RoomService(
             Equipment(
                 id = provider.generate(),
                 type = type,
-                roomId = room.id ?: throw RoomCreateException()
+                roomId = room.id
             )
         }.let { equipmentRepository.saveAll(it) }
         return RoomReadDTO.from(building, room, equipments)
@@ -93,11 +89,11 @@ class RoomService(
         equipmentRepository.deleteAllByRoomId(roomId)
     }
 
-    fun isValid(roomId : String, userId : String): Boolean {
+    fun isValid(roomId: String, userId: String): Boolean {
         val room = roomRepository.findById(roomId).orElseThrow { throw RoomNotFoundException() }
         val building = buildingRepository.findById(room.buildingId).orElseThrow { throw BuildingNotFoundException() }
         return building.adminId == userId
     }
 
-    fun isExist(roomId : String): Boolean = roomRepository.existsById(roomId)
+    fun isExist(roomId: String): Boolean = roomRepository.existsById(roomId)
 }

--- a/src/main/kotlin/com/teamteam/backend/domain/test/TestController.kt
+++ b/src/main/kotlin/com/teamteam/backend/domain/test/TestController.kt
@@ -1,8 +1,6 @@
 package com.teamteam.backend.domain.test
 
-import com.teamteam.backend.shared.security.User
 import io.swagger.v3.oas.annotations.Operation
-import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 

--- a/src/test/kotlin/com/teamteam/backend/domain/reservation/service/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/teamteam/backend/domain/reservation/service/ReservationServiceTest.kt
@@ -1,6 +1,5 @@
 package com.teamteam.backend.domain.reservation.service
 
-import com.teamteam.backend.domain.building.dto.BuildingReadDTO
 import com.teamteam.backend.domain.building.dto.BuildingReadSimpleDTO
 import com.teamteam.backend.domain.generator.IdentifierProvider
 import com.teamteam.backend.domain.member.dto.MemberReadDTO
@@ -19,12 +18,10 @@ import com.teamteam.backend.domain.room.service.RoomService
 import com.teamteam.backend.shared.security.User
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.endWith
 import io.mockk.every
 import io.mockk.mockk
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.LocalTime
 
 class ReservationServiceTest : BehaviorSpec({


### PR DESCRIPTION
#### 문제 상황
기존에 entity는 nullable한 형태로 구현되었습니다.
그 이유는 `@GeneratedValue` 어노테이션을 사용하려면 nullable 한 상태를 유지해야하기 때문입니다.
하지만 저는 uuid를 사용하며 해당 값을 코드에서 직접 관리하기 때문에 id가 nullable 할 필요가 없어졌습니다.
그리고 id가 nullable 해지면서 불필요한 null 값 체킹이 코드 중간중간에 들어가면서 가독성이 떨어지는 문제도 일부 있었습니다.

```kotlin
@Entity(name = "building")
class Building(
    @Id
    var id: String? = null,
    @Column(name = "admin_id")
    var adminId : String,
    var name: String,
    var location: String,
    var description: String,
    var imageUrl: String
) {
    override fun toString(): String =
        "Building(id=$id, name='$name', location='$location', description='$description', imageUrl='$imageUrl')"
}
``` 

#### 해결방법
entity에서 id 부분의 타입을 String? -> String으로 변경했습니다.

```kotlin
@Entity(name = "building")
class Building(
    @Id
    var id: String,
    @Column(name = "admin_id")
    var adminId : String,
    var name: String,
    var location: String,
    var description: String,
    var imageUrl: String
) {
    override fun toString(): String =
        "Building(id=$id, name='$name', location='$location', description='$description', imageUrl='$imageUrl')"
}
``` 

위와 같은 변경으로 아래의 id 값을 사용할 때 널값을 확인하는 로직을 삭제할 수 있게 되었습니다.

- 수정 전

```kotlin
class BuildingReadSimpleDTO(
    val id: String,
    val name: String,
    val description: String
) {
    companion object {
        fun from(building: Building) = BuildingReadSimpleDTO(
            id = building.id ?: throw BuildingNotFoundException(),
            name = building.name,
            description = building.description
        )
    }
}
``` 

- 수정 후

```kotlin
class BuildingReadSimpleDTO(
    val id: String,
    val name: String,
    val description: String
) {
    companion object {
        fun from(building: Building) = BuildingReadSimpleDTO(
            id = building.id,
            name = building.name,
            description = building.description
        )
    }
}
``` 